### PR TITLE
api call cache implementation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 go-corona-go
+.idea/

--- a/api/cache.go
+++ b/api/cache.go
@@ -1,43 +1,117 @@
 package api
 
 import (
+	"encoding/json"
 	gocache "github.com/patrickmn/go-cache"
+	"io/ioutil"
+	"os"
 	"time"
 )
 
 type Cache interface {
-	Put(string, []byte) error
-	Get(string) ([]byte, bool, error)
+	Put(string, string) error
+	Get(string) (string, bool, error)
 	Delete(string) error
 }
 
 type GoCache struct {
 	cache      *gocache.Cache
 	expiration time.Duration
+	path       string
+	needSync   bool
 }
 
-func NewGoCache(expiration time.Duration) *GoCache {
+func NewGoCache(path string, expiration time.Duration) *GoCache {
 	return &GoCache{
 		cache:      gocache.New(expiration, expiration),
 		expiration: expiration,
+		path:       path,
+		needSync:   true,
 	}
 }
 
-func (g *GoCache) Put(key string, data []byte) error {
+func (g *GoCache) Put(key string, data string) error {
+	if err := g.syncIfNeeded(); err != nil {
+		return err
+	}
+
 	g.cache.Set(key, data, g.expiration)
-	return nil
+	return g.syncToFile()
 }
 
-func (g *GoCache) Get(key string) ([]byte, bool, error) {
+func (g *GoCache) Get(key string) (string, bool, error) {
+	if err := g.syncIfNeeded(); err != nil {
+		return "", false, err
+	}
+
 	value, present := g.cache.Get(key)
 	if !present {
-		return nil, false, nil
+		return "", false, nil
 	}
 
-	return value.([]byte), true, nil
+	return value.(string), true, nil
 }
 
 func (g *GoCache) Delete(key string) error {
+	if err := g.syncIfNeeded(); err != nil {
+		return err
+	}
+
 	g.cache.Delete(key)
+	return g.syncToFile()
+}
+
+func (g *GoCache) syncIfNeeded() error {
+	if g.needSync {
+		if err := g.syncFromFile(); err != nil {
+			return err
+		}
+		g.needSync = false
+	}
+	return nil
+}
+
+func (g *GoCache) syncFromFile() error {
+	content, err := ioutil.ReadFile(g.path)
+
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if len(content) == 0 {
+		return nil
+	}
+
+	var state map[string]gocache.Item
+	if err := json.Unmarshal(content, &state); err != nil {
+		return err
+	}
+
+	g.cache = gocache.NewFrom(g.expiration, g.expiration, state)
+	return nil
+}
+
+func (g *GoCache) syncToFile() error {
+	items := g.cache.Items()
+	serialized, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+
+	fp, err := os.Create(g.path)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	_, err = fp.Write(serialized)
+	if err != nil {
+		return nil
+	}
+
 	return nil
 }

--- a/api/cache.go
+++ b/api/cache.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	gocache "github.com/patrickmn/go-cache"
+	"time"
+)
+
+type Cache interface {
+	Put(string, []byte) error
+	Get(string) ([]byte, bool, error)
+	Delete(string) error
+}
+
+type GoCache struct {
+	cache      *gocache.Cache
+	expiration time.Duration
+}
+
+func NewGoCache(expiration time.Duration) *GoCache {
+	return &GoCache{
+		cache:      gocache.New(expiration, expiration),
+		expiration: expiration,
+	}
+}
+
+func (g *GoCache) Put(key string, data []byte) error {
+	g.cache.Set(key, data, g.expiration)
+	return nil
+}
+
+func (g *GoCache) Get(key string) ([]byte, bool, error) {
+	value, present := g.cache.Get(key)
+	if !present {
+		return nil, false, nil
+	}
+
+	return value.([]byte), true, nil
+}
+
+func (g *GoCache) Delete(key string) error {
+	g.cache.Delete(key)
+	return nil
+}

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -1,20 +1,96 @@
 package api
 
 import (
+	"io/ioutil"
+	"path"
 	"reflect"
 	"testing"
 	"time"
 )
 
-func TestGoCachePutGet(t *testing.T) {
-	cache := NewGoCache(1 * time.Minute)
+func TestGoCachePersistenceUnexistingFile(t *testing.T) {
+	tempCacheFile, err := ioutil.TempDir("", "cache_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cacheFile := path.Join(tempCacheFile, "cache")
+	writer := NewGoCache(cacheFile,1 * time.Minute)
+	reader := NewGoCache(cacheFile,1 * time.Minute)
 
 	var (
 		key   = "test"
-		value = []byte("test-value")
+		value = "test-value"
 	)
 
-	err := cache.Put(key, value)
+	err = writer.Put(key, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cached, present, err := reader.Get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !present {
+		t.Fatalf("key %s must be present", key)
+	}
+
+	if !reflect.DeepEqual(value, cached) {
+		t.Fatal("cached values is not equals to written value")
+	}
+
+}
+
+func TestGoCachePersistence(t *testing.T) {
+	tempCacheFile, err := ioutil.TempFile("", "cache_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writer := NewGoCache(tempCacheFile.Name(),1 * time.Minute)
+	reader := NewGoCache(tempCacheFile.Name(),1 * time.Minute)
+
+	var (
+		key   = "test"
+		value = "test-value"
+	)
+
+	err = writer.Put(key, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cached, present, err := reader.Get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !present {
+		t.Fatalf("key %s must be present", key)
+	}
+
+	if !reflect.DeepEqual(value, cached) {
+		t.Fatal("cached values is not equals to written value")
+	}
+
+}
+
+func TestGoCachePutGet(t *testing.T) {
+	tempCacheFile,err := ioutil.TempFile("", "cache_*")
+	if err != nil{
+		t.Fatal(err)
+	}
+
+	cache := NewGoCache(tempCacheFile.Name(),1 * time.Minute)
+
+	var (
+		key   = "test"
+		value = "test-value"
+	)
+
+	err = cache.Put(key, value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +111,12 @@ func TestGoCachePutGet(t *testing.T) {
 
 
 func TestGoCacheGetNonExistentKey(t *testing.T) {
-	cache := NewGoCache(1 * time.Minute)
+	tempCacheFile,err := ioutil.TempFile("", "cache_*")
+	if err != nil{
+		t.Fatal(err)
+	}
+
+	cache := NewGoCache(tempCacheFile.Name(),1 * time.Minute)
 
 	var (
 		key   = "test"
@@ -49,21 +130,22 @@ func TestGoCacheGetNonExistentKey(t *testing.T) {
 	if present {
 		t.Fatalf("key %s must be not present", key)
 	}
-
-
 }
 
-
-
 func TestGoCachePutDeleteGet(t *testing.T) {
-	cache := NewGoCache(1 * time.Minute)
+	tempCacheFile,err := ioutil.TempFile("", "cache_*")
+	if err != nil{
+		t.Fatal(err)
+	}
+
+	cache := NewGoCache(tempCacheFile.Name(),1 * time.Minute)
 
 	var (
 		key   = "test"
-		value = []byte("test-value")
+		value = "test-value"
 	)
 
-	err := cache.Put(key, value)
+	err = cache.Put(key, value)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGoCachePutGet(t *testing.T) {
+	cache := NewGoCache(1 * time.Minute)
+
+	var (
+		key   = "test"
+		value = []byte("test-value")
+	)
+
+	err := cache.Put(key, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cached, present, err := cache.Get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !present {
+		t.Fatalf("key %s must be present", key)
+	}
+
+	if !reflect.DeepEqual(value, cached) {
+		t.Fatal("cached values is not equals to written value")
+	}
+}
+
+
+func TestGoCacheGetNonExistentKey(t *testing.T) {
+	cache := NewGoCache(1 * time.Minute)
+
+	var (
+		key   = "test"
+	)
+
+	_, present, err := cache.Get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if present {
+		t.Fatalf("key %s must be not present", key)
+	}
+
+
+}
+
+
+
+func TestGoCachePutDeleteGet(t *testing.T) {
+	cache := NewGoCache(1 * time.Minute)
+
+	var (
+		key   = "test"
+		value = []byte("test-value")
+	)
+
+	err := cache.Put(key, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cache.Delete(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, present, err := cache.Get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if present {
+		t.Fatalf("key %s must be not present", key)
+	}
+}
+

--- a/api/request.go
+++ b/api/request.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
+	DefaultCachePath     = "/tmp/.gocorona"
 	DefaultCacheDuration = 10 * time.Minute
 )
 
-var cache = NewGoCache(DefaultCacheDuration)
+var cache = NewGoCache(DefaultCachePath, DefaultCacheDuration)
 
 //ApiIndia queries the API and returns the response body containing stats about Covid-19 in India.
 func ApiIndia() ([]byte, error) {
@@ -23,7 +24,7 @@ func ApiIndia() ([]byte, error) {
 	}
 
 	if isCached {
-		return cached, nil
+		return []byte(cached), nil
 	}
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -51,7 +52,7 @@ func ApiIndia() ([]byte, error) {
 		return empty, err
 	}
 
-	if err := cache.Put(url, body); err != nil {
+	if err := cache.Put(url, string(body)); err != nil {
 		var empty []byte
 		return empty, err
 	}
@@ -70,7 +71,7 @@ func ApiIndiaTimeline() ([]byte, error) {
 	}
 
 	if isCached {
-		return cached, nil
+		return []byte(cached), nil
 	}
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -96,7 +97,7 @@ func ApiIndiaTimeline() ([]byte, error) {
 		return empty, err
 	}
 
-	if err := cache.Put(url, body); err != nil {
+	if err := cache.Put(url, string(body)); err != nil {
 		var empty []byte
 		return empty, err
 	}

--- a/api/request.go
+++ b/api/request.go
@@ -3,11 +3,28 @@ package api
 import (
 	"io/ioutil"
 	"net/http"
+	"time"
 )
+
+const (
+	DefaultCacheDuration = 10 * time.Minute
+)
+
+var cache = NewGoCache(DefaultCacheDuration)
 
 //ApiIndia queries the API and returns the response body containing stats about Covid-19 in India.
 func ApiIndia() ([]byte, error) {
 	url := "https://corona-virus-world-and-india-data.p.rapidapi.com/api_india"
+
+	cached, isCached, err := cache.Get(url)
+	if err != nil {
+		var empty []byte
+		return empty, err
+	}
+
+	if isCached {
+		return cached, nil
+	}
 
 	req, err := http.NewRequest("GET", url, nil)
 
@@ -34,13 +51,27 @@ func ApiIndia() ([]byte, error) {
 		return empty, err
 	}
 
+	if err := cache.Put(url, body); err != nil {
+		var empty []byte
+		return empty, err
+	}
+
 	return body, nil
 }
 
 // ApiIndiaTimeline queries the timeline feature of the API and returns per-day statistics.
 func ApiIndiaTimeline() ([]byte, error) {
-
 	url := "https://corona-virus-world-and-india-data.p.rapidapi.com/api_india_timeline"
+
+	cached, isCached, err := cache.Get(url)
+	if err != nil {
+		var empty []byte
+		return empty, err
+	}
+
+	if isCached {
+		return cached, nil
+	}
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -58,7 +89,17 @@ func ApiIndiaTimeline() ([]byte, error) {
 	}
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		var empty []byte
+		return empty, err
+	}
+
+	if err := cache.Put(url, body); err != nil {
+		var empty []byte
+		return empty, err
+	}
 
 	return body, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,11 @@ go 1.14
 
 require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/guptarohit/asciigraph v0.5.0
-	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/spf13/afero v1.3.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -35,6 +36,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -69,9 +71,8 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
-github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -100,13 +101,12 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 h1:VHgatEHNcBFEB7inlalqfNqw65aNkM1lGX2yt3NmbS8=
-github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -114,8 +114,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -146,7 +148,6 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/patrickmn/go-cache v1.0.0 h1:3gD5McaYs9CxjyK5AXGcq8gdeCARtd/9gJDUvVeaZ0Y=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
@@ -156,6 +157,7 @@ github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bA
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -174,7 +176,9 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -204,11 +208,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/thedevsaddam/gojsonq v1.9.1 h1:zQulEP43nwmq5EKrNWyIgJVbqDeMdC1qzXM/f5O15a0=
-github.com/thedevsaddam/gojsonq v2.3.0+incompatible h1:i2lFTvGY4LvoZ2VUzedsFlRiyaWcJm3Uh6cQ9+HyQA8=
 github.com/thedevsaddam/gojsonq/v2 v2.5.2 h1:CoMVaYyKFsVj6TjU6APqAhAvC07hTI6IQen8PHzHYY0=
 github.com/thedevsaddam/gojsonq/v2 v2.5.2/go.mod h1:bv6Xa7kWy82uT0LnXPE2SzGqTj33TAEeR560MdJkiXs=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -335,6 +338,7 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=


### PR DESCRIPTION
Solves #1 

This pull request bring the cache implementation for api calls with complete test suite, it works both in memory and on disk (we need persistence since this is a cli).

I've used the [go-cache](https://github.com/patrickmn/go-cache) library and implemented json serialization as suggested in the docs for cache persistence on file system.

At the moment the cache expiration is `10 minutes` and the cache file is saved under `/tmp/.gocoronago` these are constant values defined in `api/request.go`.

We may also think about passing these values with command line flags.
